### PR TITLE
Prepending the existing CSS on config load and reload.

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,7 +133,7 @@ exports.middleware = () => (next) => (action) => {
       action.config.cursorColor = FOREGROUND_COLOR;
       action.config.borderColor = BORDER_COLOR;
       action.config.colors = COLORS;
-      action.config.css = CSS;
+      action.config.css = `${action.config.css || ''}${CSS}`;
   }
   next(action);
 };


### PR DESCRIPTION
When using `hyper-firewatch` with `hyper-statusline`, the statusline styles were being omitted by the theme's middleware.